### PR TITLE
Remove complexity

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -26,9 +26,6 @@ cmd.option('--compiler <CMD>', 'specify the compiler to spawn');
 
 cmd.option('-v, --verbose', 'enable verbose logging mode');
 
-cmd.option('--no-client', 'disable client');
-cmd.option('--no-compiler', 'disable compilation');
-
 cmd.version(pkg.version);
 cmd.parse(process.argv);
 

--- a/cmd.js
+++ b/cmd.js
@@ -33,13 +33,6 @@ cmd.version(pkg.version);
 cmd.parse(process.argv);
 
 cmd.cwd = process.cwd();
-if (cmd.client !== false) {
-  cmd.client = process.env['AMOK_CLIENT'];
-}
-
-if (cmd.compiler !== false) {
-  cmd.compiler = process.env['AMOK_COMPILER'];
-}
 
 function compiler(callback, data) {
   if (cmd.compiler) {

--- a/index.js
+++ b/index.js
@@ -54,6 +54,15 @@ function compile(options, callback) {
       ];
       break;
 
+    case 'webpack':
+      var command = 'webpack';
+      var args = [
+        '--watch',
+        '--output-file',
+        options.output,
+      ];
+      break;
+
     default:
       var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);
       var command = args.shift();

--- a/index.js
+++ b/index.js
@@ -63,6 +63,15 @@ function compile(options, callback) {
       ];
       break;
 
+    case 'typescript':
+      var command = 'tsc';
+      var args = [
+        '--watch',
+        '--out',
+        options.output,
+      ];
+      break;
+
     default:
       var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);
       var command = args.shift();

--- a/index.js
+++ b/index.js
@@ -72,6 +72,16 @@ function compile(options, callback) {
       ];
       break;
 
+    case 'coffeescript':
+      var command = 'coffee';
+      var args = [
+        '--watch',
+        '--out',
+        options.output,
+      ];
+      break;
+
+
     default:
       var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);
       var command = args.shift();

--- a/index.js
+++ b/index.js
@@ -81,6 +81,14 @@ function compile(options, callback) {
       ];
       break;
 
+    case 'babel':
+      var command = 'babel';
+      var args = [
+        '--watch',
+        '--out-file',
+        options.output,
+      ];
+      break;
 
     default:
       var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var mime = require('mime');
 var path = require('path');
 var rdbg = require('rdbg');
 var util = require('util');
+var temp = require('temp');
 
 function serve(options, callback) {
   var server = http.createServer(function(request, response) {
@@ -95,13 +96,53 @@ function debug(options, callback) {
 }
 
 function open(options, callback) {
-  var args = options.client.match(/'[^"]*'|"[^"]*"|\S+/g);
-  var cmd = args.shift();
+  switch (options.client) {
+    case 'chrome':
+      var command = (function() {
+        if (process.platform == 'win32') {
+          var suffix = '\\Google\\Chrome\\Application\\chrome.exe';
+          var prefixes = [
+            process.env['LOCALAPPDATA'],
+            process.env['PROGRAMFILES'],
+            process.env['PROGRAMFILES(X86)'],
+          ];
+
+          var executables = prefixes.map(function(prefix) {
+            return prefix + suffix;
+          }).filter(function(path) {
+            return fs.existsSync(path);
+          });
+
+          return executables[0];
+        } else if (process.platform == 'darwin') {
+          return '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+        } else {
+          return 'google-chrome';
+        }
+      }());
+
+      var args = [
+        '--remote-debugging-port=' + options.debuggerPort,
+        '--no-first-run',
+        '--no-default-browser-check',
+        '--disable-translate',
+        '--disable-default-apps',
+        '--disable-popup-blocking',
+        '--disable-zero-browsers-open-for-tests',
+        '--user-data-dir=' + temp.mkdirSync('amok-chrome'),
+      ];
+      break;
+
+    default:
+      var args = options.client.match(/'[^"]*'|"[^"]*"|\S+/g);
+      var command = args.shift();
+      break;
+  }
 
   var url = util.format('http://%s:%d', options.host, options.port);
   args.push(url);
 
-  var client = child.spawn(cmd, args);
+  var client = child.spawn(command, args);
 
   process.nextTick(function() {
     callback(null, client.stdout, client.stderr);

--- a/index.js
+++ b/index.js
@@ -45,17 +45,24 @@ function serve(options, callback) {
 }
 
 function compile(options, callback) {
-  var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);
+  switch (options.compiler) {
+    case 'browserify':
+      var command = 'watchify';
+      var args = [
+        '-o',
+        options.output,
+      ];
+      break;
 
-  var cmd = args.shift();
+    default:
+      var args = options.compiler.match(/'[^"]*'|"[^"]*"|\S+/g);
+      var command = args.shift();
+      break;
+  }
 
   args = args.concat(options.args);
 
-  if (args.indexOf('$@') > -1) {
-    args[args.indexOf('$@')] = options.output;
-  }
-
-  var compiler = child.spawn(cmd, args);
+  var compiler = child.spawn(command, args);
   process.nextTick(function() {
     callback(null, compiler.stdout, compiler.stderr);
   });


### PR DESCRIPTION
An effort at simplifying the command line interface, removing complexities that throw users a curveball By implementing smarter spawns (#34) and simplifying the interface.

- [x] Remove environment variables
- [x] Remove `--no-compiler` and `--no-client` options, redundant without environment variables
- [x] Add default spawn command and arguments for `--client chrome`
- [x] Add default spawn command and arguments for `--compiler webpack`
- [x] Add default spawn command and arguments for `--compiler browserify` 
- [x] Add default spawn command and arguments for `--compiler babel`
- [x] Add default spawn command and arguments for `--compiler typescript` 
- [x] Add default spawn command and arguments for `--compiler coffeescript` 

For the motivation, see #30, #31, #27, and #35, the current interface is very prone to error and causes more problems than it solves.