### PR TITLE
Implemented preloading capability

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -28,7 +28,6 @@ cmd.option('--css <FILE(S)>', 'comma-separated list of css files to preload');
 cmd.option('--js <FILE(S)>', 'comma-separated list of JS files to preload');
 cmd.option('--head', 'inject preloaded JS into <head> (default)');
 cmd.option('--body', 'inject preloaded JS into <body>');
-cmd.option('--div', 'inject a <div> with id="main" into <body>');
 
 cmd.option('-v, --verbose', 'enable verbose logging mode');
 

--- a/cmd.js
+++ b/cmd.js
@@ -24,6 +24,12 @@ cmd.option('-i, --interactive', 'enable interactive mode');
 cmd.option('--client <CMD>', 'specify the client to spawn');
 cmd.option('--compiler <CMD>', 'specify the compiler to spawn');
 
+cmd.option('--css <FILE(S)>', 'comma-separated list of css files to preload');
+cmd.option('--js <FILE(S)>', 'comma-separated list of JS files to preload');
+cmd.option('--head', 'inject preloaded JS into <head> (default)');
+cmd.option('--body', 'inject preloaded JS into <body>');
+cmd.option('--div', 'inject a <div> with id="main" into <body>');
+
 cmd.option('-v, --verbose', 'enable verbose logging mode');
 
 cmd.version(pkg.version);

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ function serve(options, callback) {
       if (preloadBody) {
         /* loads libraries into <body> */
         response.write('</head><body>');
+        if (options.div) {
+          /* destination for React.render() */
+          response.write('<div id="main"></div>');
+        }
       }
       for (; i < jsTotal; ++i ) {
         response.write('<script src="' + js[i] + '"></script>');
@@ -35,10 +39,10 @@ function serve(options, callback) {
       if (!preloadBody) {
         /* loads libraries into <head> */
         response.write('</head><body>');
-      }
-      if (options.div) {
-        /* destination for React.render() */
-        response.write('<div id="main"></div>');
+        if (options.div) {
+          /* destination for React.render() */
+          response.write('<div id="main"></div>');
+        }
       }
       for (var key in options.scripts) {
         response.write('<script src="' + key + '"></script>');

--- a/index.js
+++ b/index.js
@@ -13,8 +13,33 @@ function serve(options, callback) {
   var server = http.createServer(function(request, response) {
     if (request.url == '/') {
       response.setHeader('content-type', 'text/html');
-      response.write('<!doctype html><head><meta charset="utf-8"></head><body>');
-
+      response.write('<!doctype html><head><meta charset="utf-8">');
+      var preloadBody = (options.body && !options.head),
+          regComma = /\, ?/g,
+          css = (options.css) ? options.css.split(regComma) : '',
+          js = (options.js) ? options.js.split(regComma) : '',
+          cssTotal = css.length,
+          jsTotal = js.length,
+          a = 0,
+          i = 0;
+      for (; a < cssTotal; ++a ) {
+        response.write('<link rel="stylesheet" href="' + css[a] + '" type="text/css" />');
+      }
+      if (preloadBody) {
+        /* loads libraries into <body> */
+        response.write('</head><body>');
+      }
+      for (; i < jsTotal; ++i ) {
+        response.write('<script src="' + js[i] + '"></script>');
+      }
+      if (!preloadBody) {
+        /* loads libraries into <head> */
+        response.write('</head><body>');
+      }
+      if (options.div) {
+        /* destination for React.render() */
+        response.write('<div id="main"></div>');
+      }
       for (var key in options.scripts) {
         response.write('<script src="' + key + '"></script>');
       }

--- a/index.js
+++ b/index.js
@@ -28,10 +28,6 @@ function serve(options, callback) {
       if (preloadBody) {
         /* loads libraries into <body> */
         response.write('</head><body>');
-        if (options.div) {
-          /* destination for React.render() */
-          response.write('<div id="main"></div>');
-        }
       }
       for (; i < jsTotal; ++i ) {
         response.write('<script src="' + js[i] + '"></script>');
@@ -39,10 +35,6 @@ function serve(options, callback) {
       if (!preloadBody) {
         /* loads libraries into <head> */
         response.write('</head><body>');
-        if (options.div) {
-          /* destination for React.render() */
-          response.write('<div id="main"></div>');
-        }
       }
       for (var key in options.scripts) {
         response.write('<script src="' + key + '"></script>');

--- a/readme.markdown
+++ b/readme.markdown
@@ -41,7 +41,22 @@ Additional features include a zero configuration http development server for dev
 
 --compiler <identifier>
   specify the compiler to spawn
-
+  
+--css <FILE(S)>
+  comma-separated list of css files to preload
+  
+--js <FILE(S)>
+  comma-separated list of JS files to preload
+  
+--head
+  inject preloaded JS into <head> (default)
+  
+--body
+  inject preloaded JS into <body>
+  
+--div
+  inject a <div> with id="main" into <body>
+  
 -i, --interactive
   start in interactive mode
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -54,9 +54,6 @@ Additional features include a zero configuration http development server for dev
 --body
   inject preloaded JS into <body>
   
---div
-  inject a <div> with id="main" into <body>
-  
 -i, --interactive
   start in interactive mode
 


### PR DESCRIPTION
This allows CSS stylesheets and JS libraries to be injected on first load via command-line (comma-separated).  The option to place the JS in the `<head>` or `<body>` tags is also available.

Changing these preloaded files will provide no live change to the page because they are not re-compiled like the input JS file (separate actions entirely).  The file watcher will still notice changes on them of course and report in console with `-v` enabled accordingly.

Readme file updated where appropriate.  