### PR TITLE
Use fs.watch directly

### DIFF
--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -91,19 +91,20 @@ function plugin() {
           }
 
           if (pending[filename]) {
-            clearTimeout(pending[filename]);
+            return;
           }
 
-          pending[filename] = setTimeout(function read() {
-            pending[filename] = false;
+          pending[filename] = true;
+          setTimeout(function () {
             fs.readFile(filename, 'utf-8', function (error, source) {
+              pending[filename] = false;
+
               if (error) {
                 debug('read error %s', error.message);
                 return client.emit('error', error);
               }
 
               if (source.length === 0) {
-                pending[filename] = setTimeout(read, 1000);
                 return;
               }
 

--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -1,4 +1,4 @@
-var chokidar = require('chokidar');
+var fs = require('fs');
 var util = require('util');
 var fs = require('fs');
 var url = require('url');
@@ -6,120 +6,132 @@ var path = require('path');
 
 var debug = util.debuglog('amok-hotpatch');
 
-function plugin(glob, options) {
-  if (typeof options === 'undefined') {
-    options = {};
-  }
-
+function plugin() {
   return function hotpatch(client, runner, done) {
-    var sources = runner.get('scripts') || {}
-    var cwd = runner.get('cwd') || process.cwd();
+    var pending = {};
+    var watchers = {};
+    var scripts = {};
 
-    var dirnames = Object.keys(sources).map(function (src) {
-      return path.dirname(sources[src]);
-    });
+    client.on('close', function () {
+      debug('client close');
+      Object.keys(watchers).forEach(function (key) {
+        debug('close watcher %s', key);
+        watchers[key].close();
+      });
 
-    if (typeof glob === 'string') {
-      dirnames.push(glob);
-    }
-
-    debug('watch %s', dirnames.join(' '));
-    var watcher = chokidar.watch(dirnames, {
-      alwaysStat: true
-    });
-
-    watcher.once('error', function bail(error) {
-      debug('bail %s', error.description);
-      done(error);
-    });
-
-    watcher.once('ready', function ready() {
-      debug('ready');
-      done();
-    });
-
-    runner.once('close', function close() {
-      debug('close');
-      watcher.close();
+      pending = {};
+      watchers = {};
+      scripts = {};
     });
 
     client.on('connect', function () {
-      debug('connect');
+      debug('client connect');
 
-      var scripts = [];
+      var cwd = runner.get('cwd');
+      if (typeof cwd === 'undefined') {
+        cwd = process.cwd();
+      }
+
+      var sources = runner.get('scripts');
+      if (typeof sources === 'undefined') {
+        sources = {};
+      }
 
       client.debugger.on('clear', function () {
-        debug('clear');
-        scripts.slice(0, scripts.length);
+        debug('debugger clear');
+        scripts = {};
       });
 
       client.debugger.on('scriptParse', function (script) {
-        var scriptUrl = url.parse(script.url);
+        if (!script.url) {
+          return;
+        }
 
-        if (scriptUrl.protocol === 'file:') {
-          script.filename = path.normalize(scriptUrl.pathname);
-        } else if (scriptUrl.protocol === 'http:') {
-          if (sources[scriptUrl.pathname.slice(1)]) {
-            script.filename = sources[scriptUrl.pathname.slice(1)];
+        var uri = url.parse(script.url);
+        var filename = null;
+
+        if (uri.protocol === 'file:') {
+          filename = path.normalize(uri.pathname);
+          if (filename.match(/^\\[a-zA-Z]:\\/)) {
+            filename = filename.slice(1);
+          }
+        } else if (uri.protocol === 'http:') {
+          filename = uri.pathname.slice(1);
+          if (sources[filename]) {
+            filename = path.resolve(sources[filename]);
           } else {
-            script.filename = path.resolve(cwd, scriptUrl.pathname.slice(1));
+            filename = path.resolve(cwd, filename);
           }
         }
 
-        if (script.filename) {
-          scripts.push(script);
-          debug('parse %s', util.inspect(script));
-        }
-      });
-
-      watcher.on('change', function change(filename, stat) {
-        debug('change %s', filename);
-
-        if (stat.size === 0) {
-          return debug('stat size 0');
+        scripts[filename] = script;
+        debug('script parse %s', util.inspect(script));
+        
+        var dirname = path.dirname(filename);
+        if (watchers[dirname]) {
+          return;
         }
 
-        var script = scripts.filter(function (script) {
-          if (script.filename === undefined) {
-            return false;
+        debug('create watcher %s', dirname);
+        var watcher = fs.watch(dirname);
+
+        watchers[dirname] = watcher;
+        watcher.on('error', function (error) {
+          debug('watch error %s', error.message);
+          client.error('error', error);
+        });
+
+        watcher.on('change', function (event, filename) {
+          filename = path.resolve(dirname, filename || '');
+          debug('%s %s', event, filename);
+
+          var script = scripts[filename];
+          if (!script) {
+            return debug('skip %s', filename);
           }
 
-          return path.resolve(script.filename) === path.resolve(filename);
-        })[0];
-
-        if (script === undefined) {
-          return debug('skip %s', filename);
-        }
-
-        debug('read %s', script.filename);
-        fs.readFile(script.filename, 'utf-8', function (error, source) {
-          if (error) {
-            return client.emit('error', error);
+          if (pending[filename]) {
+            clearTimeout(pending[filename]);
           }
 
-          debug('patch %s %d', script.url, source.length);
-          client.debugger.setScriptSource(script, source, function (error, result) {
-            if (error) {
-              debug('error %s', util.inspect(error));
-              return client.emit('error', error);
-            }
-
-            var detail = JSON.stringify({
-              detail: {
-                filename: path.relative(cwd, filename),
-                source: source,
-              }
-            });
-
-            var cmd = 'var event = new CustomEvent(\'patch\',' +
-              detail + ');\nwindow.dispatchEvent(event);';
-
-            debug('dispatch');
-            client.runtime.evaluate(cmd, function (error) {
+          pending[filename] = setTimeout(function read() {
+            pending[filename] = false;
+            fs.readFile(filename, 'utf-8', function (error, source) {
               if (error) {
-                debug('error %s', util.inspect(error));
+                debug('read error %s', error.message);
                 return client.emit('error', error);
               }
+
+              if (source.length === 0) {
+                pending[filename] = setTimeout(read, 1000);
+                return;
+              }
+
+              debug('patch script %s (%d bytes) ', script.url, source.length);
+              client.debugger.setScriptSource(script, source, function (error, result) {
+                if (error) {
+                  debug('set source error %s', util.inspect(error));
+                  return client.emit('error', error);
+                }
+
+                var detail = JSON.stringify({
+                  detail: {
+                    filename: path.relative(cwd, filename),
+                    source: source,
+                  }
+                });
+
+                var cmd = 'var event = new CustomEvent(\'patch\',' +
+                  detail + ');\nwindow.dispatchEvent(event);';
+
+                debug('evaluate patch event');
+                client.runtime.evaluate(cmd, function (error) {
+                  if (error) {
+                    debug('evaluate error %s', util.inspect(error));
+                    return client.emit('error', error);
+                  }
+                });
+              });
             });
           });
         });
@@ -141,6 +153,9 @@ function plugin(glob, options) {
         debug('runtime');
       });
     });
+
+    debug('done');
+    done();
   };
 }
 

--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -57,8 +57,8 @@ function plugin() {
           }
         } else if (uri.protocol === 'http:') {
           filename = uri.pathname.slice(1);
-          if (sources[filename]) {
-            filename = path.resolve(sources[filename]);
+          if (sources[path.normalize(filename)]) {
+            filename = path.resolve(sources[path.normalize(filename)]);
           } else {
             filename = path.resolve(cwd, filename);
           }

--- a/lib/watch.js
+++ b/lib/watch.js
@@ -1,4 +1,3 @@
-var chokidar = require('chokidar');
 var fs = require('fs');
 var path = require('path');
 var url = require('url');
@@ -6,56 +5,110 @@ var util = require('util');
 
 var debug = util.debuglog('amok-watch');
 
-function plugin(glob) {
+function plugin(pattern, ignore) {
   return function watch(client, runner, done) {
-    var files = runner.get('scripts') || {};
-    var cwd = runner.get('cwd') || process.cwd();
+    var watchers = {};
+    var stats = {};
+    var pending = {};
 
-    debug('watch %s', glob);
+    client.on('close', function () {
+      debug('client close');
 
-    var watcher = chokidar.watch(glob, {
-      ignoreInitial: true,
-      cwd: cwd,
-    });
+      Object.keys(watchers).forEach(function (key) {
+        if (watchers[key]) {
+          debug('close watcher %s', key);
+          watchers[key].close();
+        }
+      });
 
-    watcher.once('error', function error(error) {
-      debug('error %s', util.inspect(error));
-      done(error);
-    });
-
-    watcher.once('ready', function ready() {
-      debug('ready');
-      done();
-    });
-
-    runner.once('close', function close() {
-      debug('close');
-      watcher.close();
+      watchers = {};
+      pending = {};
     });
 
     client.on('connect', function () {
-      var events = ['add', 'change', 'unlink'];
-      events.forEach(function (event) {
-        watcher.on(event, function emit(filename) {
-          debug('%s %s', event, filename);
+      debug('connect');
 
-          var detail = JSON.stringify({
-            detail: {
-              filename: url.resolve('/', filename).slice(1)
-            }
-          });
+      var cwd = runner.get('cwd') || process.cwd();
 
-          var cmd = 'var event = new CustomEvent(\'' + event + '\',' +
-            detail + ');\nwindow.dispatchEvent(event);';
+      setTimeout(function watch(dirname) {
+        fs.readdir(dirname, function dir(error, files) {
 
-          client.runtime.evaluate(cmd, function (error, result) {
-            if (error) {
-              debug('error %s', error.description);
-              return client.emit('error', error);
-            }
+          files.forEach(function (file) {
+            var filename = path.resolve(dirname, file);
+
+            fs.stat(filename, function (error, stat) {
+              if (error) {
+                return;
+              }
+
+              stats[filename] = stat;
+
+              if (stat.isDirectory()) {
+                setTimeout(watch, 0, filename);
+              }
+            });
           });
         });
-      });
+
+        debug('create watcher %s', dirname);
+        var watcher = fs.watch(dirname);
+        watchers[dirname] = watcher;
+
+        watcher.on('error', function (error) {
+          debug('watch error %s', error);
+          return client.emit('error', error);
+        });
+
+        watcher.on('change', function (event, filename) {
+          filename = path.resolve(dirname, filename);
+
+          if (pending[filename]) {
+            clearTimeout(pending[filename]);
+          }
+
+          pending[filename] = setTimeout(function () {
+            fs.stat(filename, function (error, stat) {
+              if (stats[filename]) {
+                if (error) {
+                  event = 'unlink';
+
+                  if (watchers[filename]) {
+                    watchers[filename].close();
+                    watchers[filename] = null;
+                  }
+                } else {
+                  event = 'change';
+                }
+              } else if (stat) {
+                event = 'add';
+
+                if (stat.isDirectory()) {
+                  setTimeout(watch, 0, filename);
+                }
+              }
+
+              stats[filename] = stat;
+
+              var pathname = path.relative(cwd, filename);
+              var detail = JSON.stringify({
+                detail: {
+                  filename: url.resolve('/', pathname).slice(1)
+                }
+              });
+
+              var cmd = 'var event = new CustomEvent(\'' + event + '\',' +
+                detail + ');\nwindow.dispatchEvent(event);';
+
+              client.runtime.evaluate(cmd, function (error, result) {
+                if (error) {
+                  debug('evaluate error %s', error.description);
+                  return client.emit('error', error);
+                }
+              });
+            });
+          });
+        });
+      }, 0, cwd);
 
       client.runtime.enable(function (error) {
         if (error) {
@@ -65,6 +118,9 @@ function plugin(glob) {
         debug('runtime');
       });
     });
+
+    debug('done');
+    done();
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "browser_process": "^1.0.0",
-    "chokidar": "^1.0.3",
     "commander": "^2.8.1",
     "compiler_process": "^1.0.0",
     "mime": "^1.3.4",

--- a/test/cli.js
+++ b/test/cli.js
@@ -320,11 +320,13 @@ browsers.forEach(function (browser) {
 
     var args = [
       'bin/amok.js',
+      '--cwd',
+      'test/fixture/watch-events',
       '--watch',
       '**/*.txt',
       '--browser',
       browser,
-      'test/fixture/watch-events/index.js',
+      'index.js',
     ];
 
     test.comment(args.join(' '));
@@ -337,9 +339,9 @@ browsers.forEach(function (browser) {
 
     var messages = [
       'ready',
-      'add test/fixture/watch-events/file.txt',
-      'change test/fixture/watch-events/file.txt',
-      'unlink test/fixture/watch-events/file.txt'
+      'add file.txt',
+      'change file.txt',
+      'unlink file.txt'
     ];
 
     cli.stdout.setEncoding('utf-8');
@@ -353,9 +355,9 @@ browsers.forEach(function (browser) {
 
         if (line === 'ready') {
           fs.writeFileSync('test/fixture/watch-events/file.txt', 'hello', 'utf-8');
-        } else if (line === 'add test/fixture/watch-events/file.txt') {
+        } else if (line === 'add file.txt') {
           fs.writeFileSync('test/fixture/watch-events/file.txt', 'hello world', 'utf-8');
-        } else if (line === 'change test/fixture/watch-events/file.txt') {
+        } else if (line === 'change file.txt') {
           fs.unlinkSync('test/fixture/watch-events/file.txt');
         }
 

--- a/test/watch.js
+++ b/test/watch.js
@@ -11,7 +11,7 @@ var browsers = [
 
 browsers.forEach(function (browser, index) {
   test('watch events in ' + browser, function (test) {
-    test.plan(7);
+    test.plan(9);
 
     var runner = amok.createRunner();
     runner.on('close', function () {
@@ -30,9 +30,11 @@ browsers.forEach(function (browser, index) {
 
       var values = [
         'ready',
-        'add file.txt',
-        'change file.txt',
-        'unlink file.txt'
+        'add dir',
+        'add dir/file.txt',
+        'change dir/file.txt',
+        'unlink dir/file.txt',
+        'unlink dir'
       ];
 
       runner.client.console.on('data', function (message) {
@@ -41,11 +43,15 @@ browsers.forEach(function (browser, index) {
         if (values[0] === undefined) {
           runner.close();
         } if (message.text === 'ready') {
-          fs.writeFileSync('test/fixture/watch-events/file.txt', 'hello', 'utf-8');
-        } else if (message.text === 'add file.txt') {
-          fs.writeFileSync('test/fixture/watch-events/file.txt', 'hello world', 'utf-8');
-        } else if (message.text === 'change file.txt') {
-          fs.unlinkSync('test/fixture/watch-events/file.txt');
+          fs.mkdirSync('test/fixture/watch-events/dir');
+        } else if (message.text === 'add dir') {
+          fs.writeFileSync('test/fixture/watch-events/dir/file.txt', 'hello', 'utf-8');
+        } else if (message.text === 'add dir/file.txt') {
+          fs.writeFileSync('test/fixture/watch-events/dir/file.txt', 'hello world', 'utf-8');
+        } else if (message.text === 'change dir/file.txt') {
+          fs.unlinkSync('test/fixture/watch-events/dir/file.txt');
+        } else if (message.text === 'unlink dir/file.txt') {
+          fs.rmdirSync('test/fixture/watch-events/dir');
         }
       });
 


### PR DESCRIPTION
Removes chokidar from both watch and hot patch, fsevents already being in node-core it does not have that much to offer.

This gets rid of the apparent failure on install (fsevents failing)