### PR TITLE
Use fs.watch instead of chokidar for hotpatch

### DIFF
--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -1,4 +1,3 @@
-var chokidar = require('chokidar');
 var util = require('util');
 var fs = require('fs');
 var url = require('url');
@@ -8,7 +7,6 @@ var debug = util.debuglog('amok-hotpatch');
 
 function plugin() {
   return function hotpatch(client, runner, done) {
-    var sources = runner.get('scripts') || {};
     var cwd = runner.get('cwd');
     if (cwd) {
       cwd = path.resolve(cwd);
@@ -16,47 +14,40 @@ function plugin() {
       cwd = process.cwd();
     }
 
-    var dirnames = Object.keys(sources).map(function (src) {
-      return path.dirname(sources[src]);
-    });
+    var scripts = {};
+    var watchers = {};
 
-    if (dirnames.length === 0) {
-      dirnames.push(cwd);
-    }
-
-    debug('watch %s', dirnames.join(' '));
-    var watcher = chokidar.watch(dirnames, {
-      alwaysStat: true
-    });
-
-    watcher.once('error', function bail(error) {
-      debug('bail %s', error.description);
-      done(error);
-    });
-
-    watcher.once('ready', function ready() {
-      debug('ready');
-      done();
-    });
-
-    runner.once('close', function close() {
+    client.on('close', function () {
       debug('close');
-      watcher.close();
+      scripts = {};
+
+      Object.keys(watchers).forEach(function (key) {
+        watchers[key].close();
+      });
+
+      watchers = {};
     });
 
     client.on('connect', function () {
       debug('connect');
 
-      var scripts = {};
-
       client.debugger.on('clear', function () {
         debug('clear');
         scripts = {};
+
+        Object.keys(watchers).forEach(function (key) {
+          watchers[key].close();
+        });
+
+        watchers = {};
       });
 
       client.debugger.on('scriptParse', function (script) {
+        debug('parse %s', util.inspect(script));
+
         var uri = url.parse(script.url);
         var filename = null;
+        var sources = runner.get('scripts') || {};
 
         if (uri.protocol === 'file:') {
           filename = path.normalize(uri.pathname);
@@ -72,54 +63,79 @@ function plugin() {
           }
         }
 
-        if (filename) {
-          scripts[filename] = script;
+        if (!filename) {
+          return;
         }
 
-        debug('parse %s', util.inspect(script));
-      });
-
-      watcher.on('change', function change(filename, stat) {
-        debug('change %s', filename);
-
-        if (stat.size === 0) {
-          return debug('stat size 0');
+        scripts[filename] = script;
+        if (watchers[filename]) {
+          return;
         }
 
-        var script = scripts[filename];
-        if (script === undefined) {
-          return debug('skip %s', filename);
-        }
+        var dirname = path.dirname(filename);
 
-        debug('read %s', filename);
-        fs.readFile(filename, 'utf-8', function (error, source) {
-          if (error) {
-            return client.emit('error', error);
+        debug('watch directory %s', dirname);
+        var watcher = fs.watch(dirname);
+        watchers[dirname] = watcher;
+
+        var streams = {};
+        watcher.on('change', function (event, filename) {
+          if (!filename) {
+            return;
           }
 
-          debug('patch %s %d', script.url, source.length);
-          client.debugger.setScriptSource(script, source, function (error, result) {
-            if (error) {
-              debug('error %s', util.inspect(error));
-              return client.emit('error', error);
+          filename = path.resolve(dirname, filename);
+
+          var script = scripts[filename];
+          if (!script) {
+            return;
+          }
+
+          debug(event, filename);
+          if (streams[filename]) {
+            return;
+          }
+
+          var source = '';
+          var stream = fs.createReadStream(filename);
+          streams[filename] = stream;
+
+          stream.setEncoding('utf-8');
+          stream.on('data', function(chunk) {
+            source += chunk;
+          });
+
+          stream.on('end', function() {
+            streams[filename] = null;
+
+            if (source.length === 0) {
+              return;
             }
 
-            var detail = JSON.stringify({
-              detail: {
-                filename: path.relative(cwd, filename),
-                source: source,
-              }
-            });
-
-            var cmd = 'var event = new CustomEvent(\'patch\',' +
-              detail + ');\nwindow.dispatchEvent(event);';
-
-            debug('dispatch');
-            client.runtime.evaluate(cmd, function (error) {
+            debug('patch script %s (%d bytes) ', script.url, source.length);
+            client.debugger.setScriptSource(script, source, function (error, result) {
               if (error) {
-                debug('error %s', util.inspect(error));
+                debug('set source error %s', util.inspect(error));
                 return client.emit('error', error);
               }
+
+              var detail = JSON.stringify({
+                detail: {
+                  filename: path.relative(cwd, filename),
+                  source: source,
+                }
+              });
+
+              var cmd = 'var event = new CustomEvent(\'patch\',' +
+              detail + ');\nwindow.dispatchEvent(event);';
+
+              debug('evaluate patch event');
+              client.runtime.evaluate(cmd, function (error) {
+                if (error) {
+                  debug('evaluate error %s', util.inspect(error));
+                  return client.emit('error', error);
+                }
+              });
             });
           });
         });
@@ -141,6 +157,9 @@ function plugin() {
         debug('runtime');
       });
     });
+
+    debug('done');
+    done();
   };
 }
 


### PR DESCRIPTION
Chokidar's throttling causes more issues than it solves, trying to read a file when it's been truncated leads to a file size of zero but with no more events inbound when do you read the file, etc. `fs.watch` is more predictable in this scenario.

Watch still uses chokidar, because recursive watching is a pain to do.