### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: node_js
+node_js:
+  - "0.11"
+  - "0.12"
+  - "iojs"
+
+before_install:
+  - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+  - sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'
+  - sudo apt-get update
+  - sudo apt-get install google-chrome-stable
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"


### PR DESCRIPTION
Closes #83, going with travis instead of codeship.

Hopefully we'll get OS X workers too for travis-ci, then appveyor for windows.