### PR TITLE
Only test with node v0.12 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - "0.11"
   - "0.12"
-  - "iojs"
 
 before_install:
   - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -


### PR DESCRIPTION
Closes #118 by brute force, e.g removing everything but a single matrix.

Will have to look more into the core cause of why the full test matrix is failing but this will do for now, better to have one version covered and working with the repo than false negatives. 