### PR TITLE
fix scripts path on windows

### DIFF
--- a/lib/compiler.js
+++ b/lib/compiler.js
@@ -19,7 +19,7 @@ function plugin(command, args, options) {
     })[0];
 
     var dirname = temp.mkdirSync(command);
-    var pathname = entry;
+    var pathname = path.normalize(entry);
     var basename = path.basename(pathname);
     var filename = path.join(dirname, basename).replace(/\.[^\.]+$/, '.js');
 

--- a/test/lib_compiler.js
+++ b/test/lib_compiler.js
@@ -35,6 +35,7 @@ commands.forEach(function (command, index) {
       var filename = scripts[pathnames[0]];
 
       test.equal(pathnames.length, 1);
+      test.equal(pathnames[0], path.normalize(pathnames[0]));
       test.equal(fs.readFileSync(filename, 'utf-8'), fs.readFileSync(path.join(dirname, 'out.js'), 'utf-8'));
       runner.close();
     });


### PR DESCRIPTION
When using at least one folder on windows for example src/index.js, the pathname would stay src/index.js inside scripts, while in server.js it would be normalized to src\index.js. This makes it so both are normalized therefore the pathname can be correctly found inside the scripts and served by the http server.