### PR TITLE
lib: ensure debug port is open before spawn

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -2,6 +2,7 @@ var web = require('browser_process');
 var util = require('util');
 var rdbg = require('rdbg');
 var temp = require('temp');
+var net = require('net');
 
 var debug = util.debuglog('amok-browser');
 
@@ -13,51 +14,70 @@ function plugin(port, command, args, options) {
   }
 
   return function browser(client, runner, done) {
-    var url = runner.get('url');
+    var server = net.createServer();
 
-    // TODO, move into browser_process.createProfile, deleting the first run file
-    // should be equivilent of providing these options, and be compatible with how firefox does it.
-    args.unshift('--no-first-run', '--no-default-browser-check');
-    var dirname = temp.path(command);
-    args.unshift.apply(args, web.options(command, {
-      profile: dirname,
-      url: url,
-      debug: port,
-    }));
+    server.once('error', function(error) {
+      debug('server error', error);
+      done(error);
+    });
 
-    debug('spawn %s %s', command, args.join(' '));
-    web.spawn(command, args, options, function (error, browser) {
-      if (error) {
-        debug('bail %s', error.description);
-        return done(error);
-      }
+    server.once('listening', function() {
+      debug('server listening');
 
-      runner.once('close', function kill() {
-        debug('kill');
-        browser.kill('SIGTERM');
-      });
+      server.once('close', function() {
+        debug('server close');
 
-      debug('find %s', url);
+        var url = runner.get('url');
 
-      process.nextTick(function find() {
-        rdbg.get(port, 'localhost', function (error, targets) {
+        // TODO, move into browser_process.createProfile, deleting the first run file
+        // should be equivilent of providing these options, and be compatible with how firefox does it.
+        args.unshift('--no-first-run', '--no-default-browser-check');
+        var dirname = temp.path(command);
+        args.unshift.apply(args, web.options(command, {
+          profile: dirname,
+          url: url,
+          debug: port,
+        }));
+
+        debug('spawn %s %s', command, args.join(' '));
+        web.spawn(command, args, options, function (error, browser) {
           if (error) {
-            return process.nextTick(find);
+            debug('bail %s', error.description);
+            return done(error);
           }
 
-          var target = targets.filter(function (target) {
-            return url === target.url;
-          })[0];
+          runner.once('close', function kill() {
+            debug('kill process');
+            browser.kill('SIGTERM');
+          });
 
-          if (!target) {
-            return process.nextTick(find);
-          }
+          process.nextTick(function find() {
+            rdbg.get(port, 'localhost', function (error, targets) {
+              if (error) {
+                return process.nextTick(find);
+              }
 
-          debug('ready');
-          done();
+              var target = targets.filter(function (target) {
+                return url === target.url;
+              })[0];
+
+              if (!target) {
+                return process.nextTick(find);
+              }
+
+              debug('ready');
+              done();
+            });
+          });
         });
       });
+
+      debug('close server');
+      server.close();
     });
+
+    debug('starting server on port', port);
+    server.listen(port);
   };
 }
 

--- a/test/lib_browser.js
+++ b/test/lib_browser.js
@@ -1,4 +1,5 @@
 var amok = require('..');
+var net = require('net');
 var test = require('tape');
 var url = require('url');
 var path = require('path');
@@ -35,5 +36,38 @@ commands.forEach(function (command, index) {
         test.error(error);
       });
     });
+  });
+});
+
+commands.forEach(function (command, index) {
+  var port = 4000 + index;
+
+  test('error when port is used in ' + command, function (test) {
+    test.plan(2);
+    test.timeoutAfter(5000);
+
+    var server = net.createServer();
+    server.on('close', function() {
+      test.pass();
+    });
+
+    server.on('listening', function() {
+      var runner = amok.createRunner();
+      server.on('close', function () {
+        runner.close();
+      });
+
+      runner.set('url', url.resolve('file://', path.join('/' + __dirname, '/fixture/basic/index.html')));
+      runner.use(amok.browser(port, command));
+
+      runner.on('error', function(error) {
+        test.equal(error.code, 'EADDRINUSE');
+        server.close();
+      });
+
+      runner.connect(port, 'localhost');
+    });
+
+    server.listen(port);
   });
 });


### PR DESCRIPTION
If the port given to browser is occupied we would get stuck in an
loop waiting for the target tab to be available.

This addresses that by testing if the port is open before attempting to
spawn a browser. If the port is not open an error will be yielded.

This fixes #143, which is the likely cause of issues like https://github.com/caspervonb/amok/issues/140, https://github.com/caspervonb/amok/issues/139. Has popped up in chat a few times too. Way back there was a case where Gitter next was taking the port.