### PR TITLE
lib: set a limit for browser tab search

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -51,24 +51,32 @@ function plugin(port, command, args, options) {
             browser.kill('SIGTERM');
           });
 
-          process.nextTick(function find() {
+          debug('find %s', url);
+          setTimeout(function find(retry) {
             rdbg.get(port, 'localhost', function (error, targets) {
               if (error) {
-                return process.nextTick(find);
+                targets = [];
               }
 
-              var target = targets.filter(function (target) {
+              var matches = targets.filter(function (target) {
                 return url === target.url;
-              })[0];
+              });
 
-              if (!target) {
-                return process.nextTick(find);
+              if (matches.length > 0) {
+                debug('ready');
+                return done();
+              } else if (retry) {
+                return setTimeout(find, 1000, retry--);
               }
 
-              debug('ready');
-              done();
+              if (error === undefined) {
+                error = new Error('Cannot find browser tab \'' + url + '\'');
+              }
+
+              debug('find error', error);
+              done(error);
             });
-          });
+          }, 1000, 120);
         });
       });
 


### PR DESCRIPTION
In certain scenarios it is possible to get stuck waiting for the target
url to become available, this can happen if the server never sends a
response for example.

This addresses that by timing out after a certain period, with a
reasonable default of two minutes.