### PR TITLE
lib: fix hotpatch check for duplicate watchers

### DIFF
--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -68,11 +68,11 @@ function plugin() {
         }
 
         scripts[filename] = script;
-        if (watchers[filename]) {
-          return;
-        }
 
         var dirname = path.dirname(filename);
+        if (watchers[dirname]) {
+          return;
+        }
 
         debug('watch directory %s', dirname);
         var watcher = fs.watch(dirname);


### PR DESCRIPTION
This fixes the check for duplicate watchers so that it correctly use
the file directory instead of the full file path.