### PR TITLE
lib: add check for script host

### DIFF
--- a/lib/hotpatch.js
+++ b/lib/hotpatch.js
@@ -46,6 +46,7 @@ function plugin() {
         debug('parse %s', util.inspect(script));
 
         var uri = url.parse(script.url);
+        var pageUri = url.parse(runner.get('url') || '');
         var filename = null;
         var sources = runner.get('scripts') || {};
 
@@ -58,8 +59,10 @@ function plugin() {
           filename = uri.pathname.slice(1);
           if (sources[path.normalize(filename)]) {
             filename = path.resolve(sources[path.normalize(filename)]);
-          } else {
+          } else if (uri.host === pageUri.host) {
             filename = path.resolve(cwd, filename);
+          } else {
+            filename = null;
           }
         }
 


### PR DESCRIPTION
All scripts urls not part of the source map were resolved relative to
the cwd so for example:

http://externalhost.com/js/foo.js would resolve to cwd/js/foo.js

This would cause an ENOENT error to be thrown as the directory for that
file could not be found.

This fixes this issue by making sure that only urls with same host as
the page amok is running on are resolved relative to the cwd.